### PR TITLE
frame.TitleText is not supported with 10.0.2

### DIFF
--- a/CustomTutorials-2.1.lua
+++ b/CustomTutorials-2.1.lua
@@ -45,7 +45,7 @@ local function UpdateFrame(frame, i)
 	end
 
 	-- Frame
-	local title = frame.TitleText or frame.TitleContainer.TitleText
+	local title = frame.TitleContainer.TitleText
 	title:SetText(data.title or frame.data.title)
 
 	frame.text:SetPoint('BOTTOM', frame, 0, (data.textY or 20) + 30)


### PR DESCRIPTION
This is based on changes other people have made to different addons.

This should fix #7 